### PR TITLE
Only record the user to Bugsnag when there's an active user identity.

### DIFF
--- a/src/services/BugsnagService.php
+++ b/src/services/BugsnagService.php
@@ -54,11 +54,13 @@ class BugsnagService extends Component
 
                 if ( $user = Craft::$app->getUser() ) {
                     $identity = $user->getIdentity();
-                    $report->setUser([
-                        'id'    => $user->id,
-                        'name'  => $identity->getName(),
-                        'email' => $identity->email,
-                    ]);
+                    if ( $identity ) {
+                        $report->setUser([
+                            'id'    => $user->id,
+                            'name'  => $identity->getName(),
+                            'email' => $identity->email,
+                        ]);
+                    }
                 }
             });
         }


### PR DESCRIPTION
I've gotten "Call to a member function getName() on null" errors when logging exceptions for anonymous users. This seems to fix it.