### PR TITLE
Add Bootstrap and JS errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Bugsnag's cross platform error monitoring automatically detects crashes in your 
 2. Update `serverApiKey` with a API key from your Bugsnag project.
 3. (Optionally) Set the `releaseStage` configuration setting to something. Defaults to `production`.
 
+If you want to be able to capture early initialization errors, you need to add this plugin to your project's bootstrap configuration. To do this, in `config/app.php`, add:
+
+'bootstrap' => [
+    '\superbig\bugsnag\Bootstrap',
+]
+
 ### Blacklisting exceptions
 
 If you want to ignore a certain type of exception, like a 404-error, you can do it like this: 
@@ -62,5 +68,12 @@ return [
 It will automatically log most exceptions/errors. If you want to log a exceptions/error from an custom plugin, you may use the service methods:
 
 - For exceptions: `Bugsnag::$plugin->bugsnagService->handleException($exception);`
+
+## Javascript errors
+You can log Javascript errors on your site, but including the following in your Twig templates:
+
+```twig
+{% do view.registerAssetBundle('superbig\\bugsnag\\assetbundles\\frontend\\FrontEndAsset') %}
+```
 
 Brought to you by [Superbig](https://superbig.co)

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -1,0 +1,21 @@
+<?php
+namespace superbig\bugsnag;
+
+use Craft;
+use craft\base\Plugin;
+
+use yii\base\BootstrapInterface;
+
+class Bootstrap implements BootstrapInterface
+{
+    /**
+     * Installs our components during the bootstrap process to get us loaded 
+     * sooner in case something crashes.
+     *
+     * @param \yii\base\Application $app
+     */
+    public function bootstrap($app)
+    {
+        $app->getPlugins()->getPlugin('bugsnag');
+    }
+}

--- a/src/assetbundles/frontend/FrontEndAsset.php
+++ b/src/assetbundles/frontend/FrontEndAsset.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Bugsnag plugin for Craft CMS 3.x
+ *
+ * Log Craft errors/exceptions to Bugsnag.
+ *
+ * @link      https://superbig.co
+ * @copyright Copyright (c) 2017 Superbig
+ */
+
+namespace superbig\bugsnag\assetbundles\frontend;
+
+use superbig\bugsnag\Bugsnag;
+
+use Craft;
+use craft\helpers\Json;
+use craft\web\AssetBundle;
+use craft\web\View;
+
+/**
+ * @author    Superbig
+ * @package   Bugsnag
+ * @since     2.0.0
+ */
+class FrontEndAsset extends AssetBundle
+{
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        $settings = Bugsnag::$plugin->getSettings();
+
+        if (!$settings->enabled) {
+            return;
+        }
+
+        $filePath = '//d2wy8f7a9ursnm.cloudfront.net/v6/bugsnag.min.js';
+
+        $this->js[] = [
+            $filePath, 
+            'data-apikey' => $settings->serverApiKey,
+            'data-releasestage' => $settings->releaseStage,
+            'position' => View::POS_HEAD,
+        ];
+
+        // Include this wrapper since bugsnag.js might be blocked by adblockers.  We don't want to completely die if so.
+        $js = 'var Bugsnag = Bugsnag || {};';
+
+        if (!Craft::$app->user->isGuest) {
+            $currentUser = Craft::$app->user->identity;
+
+            $userInfo = Json::htmlEncode([
+                'id' => $currentUser->id,
+                'name' => $currentUser->fullName,
+                'email' => $currentUser->email,
+            ]);
+
+            $js .= "Bugsnag.user = $userInfo;";
+        }
+
+        if (!empty($settings->notifyReleaseStages)) {
+            $releaseStages = Json::htmlEncode($settings->notifyReleaseStages);
+
+            $js .= "Bugsnag.notifyReleaseStages = $releaseStages;";
+        }
+
+        Craft::$app->view->registerJs($js, View::POS_BEGIN);
+
+        parent::init();
+    }
+}


### PR DESCRIPTION
I've added support for Yii's [Bootstrap config](https://www.yiiframework.com/doc/api/2.0/yii-base-application#$bootstrap-detail), allowing errors to be caught quickly in the application lifecycle. For instance, if you had multiple modules, or even some plugins, as-is, errors won't be sent to Bugsnag.

In addition, I've added an asset bundle to add JS to capture front-end JS errors.