### PR TITLE
Expose the Bugsnag Client through the BugsnagService

### DIFF
--- a/src/services/BugsnagService.php
+++ b/src/services/BugsnagService.php
@@ -84,13 +84,10 @@ class BugsnagService extends Component
         $this->bugsnag->leaveBreadcrumb($text, $type, $metaData);
     }
 
-    /*
-     * @return mixed
-     */
     /**
      * @param $exception
      *
-     * @return bool
+     * @return bool | void
      */
     public function handleException ($exception)
     {
@@ -99,6 +96,14 @@ class BugsnagService extends Component
         }
 
         $this->bugsnag->notifyException($exception);
+    }
+
+    /**
+     * @return Client
+     */
+    public function getClient () : Client
+    {
+        return $this->bugsnag;
     }
 
     public function isEnabled ()


### PR DESCRIPTION
#16 Expose the Bugsnag Client through the BugsnagService

Allows to use notifyErrors(), notifyException() and other methods of the instantiated Bugsnag Client in other plugins / module code.